### PR TITLE
fixed installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Golang API wrapper for https://lnpay.co/.
 ## Install
 
 ```
-go get github.com/fiatjaf/lnpay
+go get github.com/fiatjaf/lnpay-go
 ```
 
 ## Usage


### PR DESCRIPTION
`go get <module>` should follow the module naming in `go.mod` and the GitHub URL. 
